### PR TITLE
chore: update learning assistant plugin 2.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/browserslist-config": "1.5.0",
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.2.0",
-        "@edx/frontend-lib-learning-assistant": "^2.22.0",
+        "@edx/frontend-lib-learning-assistant": "^2.23.0",
         "@edx/frontend-lib-special-exams": "^4.0.0",
         "@edx/frontend-platform": "^8.3.1",
         "@edx/openedx-atlas": "^0.7.0",
@@ -2413,10 +2413,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.22.0.tgz",
-      "integrity": "sha512-iSta7FE5SgNdR3YrpslT90XsnNTUNI2Pfc/OMCCTpD8046LuBlzMwCIHvXjgOqmOy2OyjV+zpqG/dQyRWT3jnQ==",
-      "license": "AGPL-3.0",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.23.0.tgz",
+      "integrity": "sha512-ajr213/hGH19iyh4y868AN212YsxLcVeSoGg9BXvltp5x9GM7k+LZK8pMEs2nRpGJ6A8QFm0wgrOYtYEFmCglQ==",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@optimizely/react-sdk": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/browserslist-config": "1.5.0",
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-component-header": "^6.2.0",
-    "@edx/frontend-lib-learning-assistant": "^2.22.0",
+    "@edx/frontend-lib-learning-assistant": "^2.23.0",
     "@edx/frontend-lib-special-exams": "^4.0.0",
     "@edx/frontend-platform": "^8.3.1",
     "@edx/openedx-atlas": "^0.7.0",


### PR DESCRIPTION
For releasing the 14 day audit trial for the Xpert Learning Assistant: https://2u-internal.atlassian.net/browse/COSMO2-103

Relevant Release: https://github.com/edx/frontend-lib-learning-assistant/releases/tag/v2.23.0