### PR TITLE
fix: modal size for lti content

### DIFF
--- a/src/courseware/course/sequence/Unit/ContentIFrame.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.jsx
@@ -78,7 +78,7 @@ const ContentIFrame = ({
       {modalOptions.isOpen
           && (
           <ModalDialog
-            dialogClassName="modal-lti"
+            className="modal-lti"
             onClose={handleModalClose}
             size={modalOptions.isFullscreen ? 'fullscreen' : 'md'}
             isOpen


### PR DESCRIPTION
Ticket: [COSMO2-716](https://2u-internal.atlassian.net/browse/COSMO2-716)
- dialogClassName was working with Modal from paragon, but after paragon v23 upgrade. We replaced Modal with ModalDialog with which dialogClassName doesn't work.
  - So, replace dialogClassName with simple className to apply same styles.
  
Please review 
paragon [v22](https://paragon-openedx-v22.netlify.app/components/modal/#props-api) Modal Props VS paragon ModalDialog Props API ModalDialog Props API which used className instead of dialogClassName.