### PR TITLE
fix: height for lti modal

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -368,7 +368,7 @@
 // size like this.  Because of the hack below around react-focus-on's div, it would be better long-term to pull this into Paragon and perhaps call it "modal-full" or something like that.
 .modal-lti {
   height: 100%;
-  max-width: 100% !important;
+  max-width: 80vh !important;
 
   // I don't like this.  We need to set a height of 100% on a div created by react-focus-on, a
   // package we use in our Modal.  That div has no class name or ID, so instead we're uniquely


### PR DESCRIPTION
Ticket: [COSMO2-716](https://2u-internal.atlassian.net/browse/COSMO2-716)
related edx PR: https://github.com/edx/frontend-app-learning/pull/12
related Upstream PR: https://github.com/openedx/frontend-app-learning/pull/1787

Before:
<img width="1792" height="1032" alt="Screenshot 2025-09-09 at 3 27 42 PM" src="https://github.com/user-attachments/assets/f4a3befb-fa88-45f6-a965-1bcdf998ec22" />

After:
<img width="1792" height="1032" alt="Screenshot 2025-09-09 at 3 28 13 PM" src="https://github.com/user-attachments/assets/ffe0a7dc-c699-494f-b97b-c2439c716d4e" />
