### PR TITLE
feat: update version of frontend-lib-learning-assistant to 2.23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/browserslist-config": "1.5.0",
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.2.0",
-        "@edx/frontend-lib-learning-assistant": "^2.23.0",
+        "@edx/frontend-lib-learning-assistant": "^2.23.1",
         "@edx/frontend-lib-special-exams": "^4.0.0",
         "@edx/frontend-platform": "^8.3.1",
         "@edx/openedx-atlas": "^0.7.0",
@@ -2413,9 +2413,10 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.23.0.tgz",
-      "integrity": "sha512-ajr213/hGH19iyh4y868AN212YsxLcVeSoGg9BXvltp5x9GM7k+LZK8pMEs2nRpGJ6A8QFm0wgrOYtYEFmCglQ==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.23.1.tgz",
+      "integrity": "sha512-0rDHlE3tlADWOcqKaVIKkMK2YGonbRaYJfmBSgH+Sn6+BFg2e541fn7NC9e5rIaiV1BnMREF7dxyRa/IEYLZLA==",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@optimizely/react-sdk": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/browserslist-config": "1.5.0",
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-component-header": "^6.2.0",
-    "@edx/frontend-lib-learning-assistant": "^2.23.0",
+    "@edx/frontend-lib-learning-assistant": "^2.23.1",
     "@edx/frontend-lib-special-exams": "^4.0.0",
     "@edx/frontend-platform": "^8.3.1",
     "@edx/openedx-atlas": "^0.7.0",


### PR DESCRIPTION
### Description

This is a cherry-pick of https://github.com/openedx/frontend-app-learning/commit/7233f08d3d073f7301e8aee02b4ef5d346dcd1d3.

This commit installs version 2.23 of [@edx/frontend-lib-learning-assistant](https://www.npmjs.com/package/@edx/frontend-lib-learning-assistant).

This release fixes a bug where the Xpert Learning Assistant was only available to learners in the audit and credit modes.

See https://github.com/edx/frontend-lib-learning-assistant/releases/tag/v2.23.1.
