### PR TITLE
feat: updated design for course outline sections and sequences, imple…

### DIFF
--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -528,7 +528,7 @@ exports[`Data layer integration tests Test fetchOutlineTab Should fetch, normali
               "hideFromTOC": undefined,
               "icon": null,
               "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@bcdabcdabcdabcdabcdabcdabcdabcd1",
-              "isPreview": undefined,
+              "isPreview": false,
               "navigationDisabled": undefined,
               "sectionId": "block-v1:edX+DemoX+Demo_Course+type@chapter+block@bcdabcdabcdabcdabcdabcdabcdabcd2",
               "showLink": true,

--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -528,6 +528,7 @@ exports[`Data layer integration tests Test fetchOutlineTab Should fetch, normali
               "hideFromTOC": undefined,
               "icon": null,
               "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@bcdabcdabcdabcdabcdabcdabcdabcd1",
+              "isPreview": undefined,
               "navigationDisabled": undefined,
               "sectionId": "block-v1:edX+DemoX+Demo_Course+type@chapter+block@bcdabcdabcdabcdabcdabcdabcdabcd2",
               "showLink": true,

--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -155,6 +155,7 @@ export function normalizeOutlineBlocks(courseId, blocks) {
           title: block.display_name,
           hideFromTOC: block.hide_from_toc,
           navigationDisabled: block.navigation_disabled,
+          isPreview: block.is_preview,
         };
         break;
 

--- a/src/shared/data/__factories__/courseBlocks.factory.js
+++ b/src/shared/data/__factories__/courseBlocks.factory.js
@@ -116,6 +116,7 @@ export function buildMinimalCourseBlocks(courseId, title, options = {}) {
       effort_activities: 2,
       effort_time: 15,
       type: 'sequential',
+      is_preview: false,
     },
     { courseId },
   )];


### PR DESCRIPTION
Implemented completion icons for sequences and section as per this figma requirement
https://www.figma.com/design/WfxE1gZJluTdtrcVCt8DKW/LMS-Navigation?node-id=3140-5214&m=dev
<img width="911" height="770" alt="courseoutlinebefore" src="https://github.com/user-attachments/assets/c88fdbe3-b05e-44e8-ac87-e41facff8aea" />
<img width="926" height="748" alt="courseoutlineafter" src="https://github.com/user-attachments/assets/8091ce89-3844-4e9a-a23d-00a8cfa143f0" />

