### PR TITLE
feat: moved upgrade notification CTA to top

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -171,6 +171,7 @@ const OutlineTab = () => {
         </div>
         {rootCourseId && (
           <div className="col col-12 col-md-4">
+            <CourseOutlineTabNotificationsSlot courseId={courseId} />
             <ProctoringInfoPanel />
             { /** Defer showing the goal widget until the ProctoringInfoPanel has resolved or has been determined as
              disabled to avoid components bouncing around too much as screen is rendered */ }
@@ -181,7 +182,6 @@ const OutlineTab = () => {
               />
             )}
             <CourseTools />
-            <CourseOutlineTabNotificationsSlot courseId={courseId} />
             <CourseDates />
             <CourseHandouts />
           </div>


### PR DESCRIPTION
Moved upgrade CTA notification panel to top of the list in right hand side 
### Before
<img width="330" height="715" alt="upgradeCTABefore" src="https://github.com/user-attachments/assets/6c29816c-71f8-40b1-9b6a-b66dc2953cb5" />

### After
<img width="312" height="716" alt="upgradeCTAAfter" src="https://github.com/user-attachments/assets/1f947c06-5160-4b85-80f9-4ec0696f412f" />

