### PR TITLE
fix: react state never updated when tour opened

### DIFF
--- a/src/product-tours/ProductTours.jsx
+++ b/src/product-tours/ProductTours.jsx
@@ -16,6 +16,7 @@ import {
   endCourseHomeTour,
   endCoursewareTour,
   fetchTourData,
+  openCourseHomeTour,
 } from './data';
 
 const ProductTours = ({
@@ -164,7 +165,7 @@ const ProductTours = ({
             is_staff: administrator,
           });
           dispatch(closeNewUserCourseHomeModal());
-          setIsNewUserCourseHomeTourEnabled(true);
+          dispatch(openCourseHomeTour());
         }}
       />
     </>

--- a/src/product-tours/data/index.js
+++ b/src/product-tours/data/index.js
@@ -3,6 +3,7 @@ export {
   endCourseHomeTour,
   endCoursewareTour,
   fetchTourData,
+  openCourseHomeTour,
 } from './thunks';
 
 export { reducer } from './slice';

--- a/src/product-tours/data/thunks.js
+++ b/src/product-tours/data/thunks.js
@@ -6,10 +6,15 @@ import {
   disableCoursewareTour,
   disableNewUserCourseHomeModal,
   setTourData,
+  launchCourseHomeTour,
 } from './slice';
 
 export function closeNewUserCourseHomeModal() {
   return async (dispatch) => dispatch(disableNewUserCourseHomeModal());
+}
+
+export function openCourseHomeTour() {
+  return async (dispatch) => dispatch(launchCourseHomeTour());
 }
 
 export function endCourseHomeTour(username) {


### PR DESCRIPTION
Previously when the user clicked the "start tour" button on the new user tour modal, we just updated the component's local state to say we should open the tour, but we never actually updated the redux state. 

This caused issues in other product tours - we were trying to make sure no other tours were showing, but even though the redux state said that no other tours were active, the course home tour was active. This should resolve the issue.