### PR TITLE
feat: [COSMO2-821] Add plugin slot for access expiration top banner

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -18,6 +18,7 @@ import ContentTools from './content-tools';
 import Sequence from './sequence';
 import { CourseOutlineMobileSidebarTriggerSlot } from '../../plugin-slots/CourseOutlineMobileSidebarTriggerSlot';
 import { CourseBreadcrumbsSlot } from '../../plugin-slots/CourseBreadcrumbsSlot';
+import { CoursewareTopBannerSlot } from '../../plugin-slots/CoursewareTopBannerSlot';
 
 const Course = ({
   courseId,
@@ -108,7 +109,7 @@ const Course = ({
           <NotificationsDiscussionsSidebarTriggerSlot courseId={courseId} />
         </div>
       </div>
-
+      <CoursewareTopBannerSlot courseId={courseId} />
       <AlertList topic="sequence" />
       <Sequence
         unitId={unitId}

--- a/src/plugin-slots/CoursewareTopBannerSlot/README.md
+++ b/src/plugin-slots/CoursewareTopBannerSlot/README.md
@@ -1,0 +1,14 @@
+# Courseware Top Banner Slot
+
+### Slot ID: `org.openedx.frontend.learning.courseware_top_banner.v1`
+
+### Slot ID Aliases
+* `courseware_top_banner_slot`
+
+### Props:
+* `courseId`
+* `model` (always set to `coursewareMeta`)
+
+## Description
+
+This slot is rendered in the courseware page shell (`Course.jsx`) above the sequence content. It is intended for top-of-courseware banners that should display in the Learning MFE chrome (not inside the LMS unit iframe).

--- a/src/plugin-slots/CoursewareTopBannerSlot/index.tsx
+++ b/src/plugin-slots/CoursewareTopBannerSlot/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+
+interface CoursewareTopBannerSlotProps {
+  courseId: string;
+}
+
+export const CoursewareTopBannerSlot = ({
+  courseId,
+}: CoursewareTopBannerSlotProps) => (
+  <PluginSlot
+    id="org.openedx.frontend.learning.courseware_top_banner.v1"
+    idAliases={['courseware_top_banner_slot']}
+    pluginProps={{
+      courseId,
+      model: 'coursewareMeta',
+    }}
+  />
+);
+
+export default CoursewareTopBannerSlot;

--- a/src/plugin-slots/README.md
+++ b/src/plugin-slots/README.md
@@ -9,6 +9,7 @@
 * [`org.openedx.frontend.learning.course_outline_sidebar_trigger.v1`](./CourseOutlineSidebarTriggerSlot)
 * [`org.openedx.frontend.learning.course_outline_sidebar.v1`](./CourseOutlineSidebarSlot/)
 * [`org.openedx.frontend.learning.course_outline_tab_notifications.v1`](./CourseOutlineTabNotificationsSlot/)
+* [`org.openedx.frontend.learning.courseware_top_banner.v1`](./CoursewareTopBannerSlot/)
 * [`org.openedx.frontend.learning.course_recommendations.v1`](./CourseRecommendationsSlot/)
 * [`org.openedx.frontend.learning.gated_unit_content_message.v1`](./GatedUnitContentMessageSlot/)
 * [`org.openedx.frontend.learning.learner_tools.v1`](./LearnerToolsSlot/)


### PR DESCRIPTION
## Summary
Adds a new PluginSlot in the Learning MFE for the learner-facing "Audit Access Expires" top banner.

## What changed
- Added a new top banner PluginSlot wrapper
- Mounted the slot in the Learning MFE page shell where the banner should appear
- Updated plugin slot documentation

## Why
The existing AccessExpirationAlert component is present in the MFE but is not wired into the UI.
This change introduces a dedicated PluginSlot so the banner can be rendered through the plugin architecture.

## Notes
- This PR does not render the banner by itself
- Actual banner UI is provided by the ads plugin
- Host config wiring is handled separately in edx-internal