### PR TITLE
fix: migrate course exit CTA ownership to monetization

### DIFF
--- a/src/courseware/course/Course.test.jsx
+++ b/src/courseware/course/Course.test.jsx
@@ -58,27 +58,25 @@ describe('Course', () => {
     global.innerWidth = breakpoints.extraLarge.minWidth;
   });
 
-  // This was passing when it shouldn't have been because of improper
-  // waitFor use. With the React 18 upgrade it no longer improperly passes
-  // so we are skipping it. See https://github.com/openedx/frontend-app-learning/issues/1669
-  // for details.
-  it.skip('loads learning sequence', () => {
+  it('loads learning sequence', async () => {
     render(<Course {...mockData} />, { wrapWithRouter: true });
     expect(screen.queryByRole('navigation', { name: 'breadcrumb' })).not.toBeInTheDocument();
-    waitFor(() => {
-      expect(screen.findByText('Loading learning sequence...')).toBeInTheDocument();
 
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Learn About Verified Certificates' })).not.toBeInTheDocument();
+    expect(await screen.findByText('Loading learning sequence...')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Learn About Verified Certificates' })).not.toBeInTheDocument();
 
-      loadUnit();
+    loadUnit();
+    await waitFor(() => {
       expect(screen.queryByText('Loading learning sequence...')).not.toBeInTheDocument();
+    });
 
-      const { models } = store.getState();
-      const sequence = models.sequences[mockData.sequenceId];
-      const section = models.sections[sequence.sectionId];
-      const course = models.coursewareMeta[mockData.courseId];
+    const { models } = store.getState();
+    const sequence = models.sequences[mockData.sequenceId];
+    const section = models.sections[sequence.sectionId];
+    const course = models.coursewareMeta[mockData.courseId];
+    await waitFor(() => {
       expect(document.title).toMatch(
         `${sequence.title} | ${section.title} | ${course.title} | edX`,
       );
@@ -106,11 +104,7 @@ describe('Course', () => {
     expect(screen.queryByRole('navigation', { name: 'breadcrumb' })).not.toBeInTheDocument();
   });
 
-  // This was passing when it shouldn't have been because of improper
-  // waitFor use. With the React 18 upgrade it no longer improperly passes
-  // so we are skipping it. See https://github.com/openedx/frontend-app-learning/issues/1669
-  // for details.
-  it.skip('displays first section celebration modal', async () => {
+  it('displays first section celebration modal', async () => {
     const courseHomeMetadata = Factory.build('courseHomeMetadata', { celebrations: { firstSection: true } });
     const testStore = await initializeTestStore({ courseHomeMetadata }, false);
     const { courseware, models } = testStore.getState();
@@ -125,18 +119,12 @@ describe('Course', () => {
     handleNextSectionCelebration(sequenceId, sequenceId, testData.unitId);
     render(<Course {...testData} />, { store: testStore, wrapWithRouter: true });
 
-    waitFor(() => {
-      const firstSectionCelebrationModal = screen.getByRole('dialog');
-      expect(firstSectionCelebrationModal).toBeInTheDocument();
-      expect(getByRole(firstSectionCelebrationModal, 'heading', { name: 'Congratulations!' })).toBeInTheDocument();
-    });
+    const firstSectionCelebrationModal = await screen.findByRole('dialog');
+    expect(firstSectionCelebrationModal).toBeInTheDocument();
+    expect(getByRole(firstSectionCelebrationModal, 'heading', { name: 'Congratulations!' })).toBeInTheDocument();
   });
 
-  // This was passing when it shouldn't have been because of improper
-  // waitFor use. With the React 18 upgrade it no longer improperly passes
-  // so we are skipping it. See https://github.com/openedx/frontend-app-learning/issues/1669
-  // for details.
-  it.skip('displays weekly goal celebration modal', async () => {
+  it('displays weekly goal celebration modal', async () => {
     const courseHomeMetadata = Factory.build('courseHomeMetadata', { celebrations: { weeklyGoal: true } });
     const testStore = await initializeTestStore({ courseHomeMetadata }, false);
     const { courseware, models } = testStore.getState();
@@ -149,11 +137,9 @@ describe('Course', () => {
     };
     render(<Course {...testData} />, { store: testStore, wrapWithRouter: true });
 
-    waitFor(() => {
-      const weeklyGoalCelebrationModal = screen.getByRole('dialog');
-      expect(weeklyGoalCelebrationModal).toBeInTheDocument();
-      expect(getByRole(weeklyGoalCelebrationModal, 'heading', { name: 'You met your goal!' })).toBeInTheDocument();
-    });
+    const weeklyGoalCelebrationModal = await screen.findByRole('dialog');
+    expect(weeklyGoalCelebrationModal).toBeInTheDocument();
+    expect(getByRole(weeklyGoalCelebrationModal, 'heading', { name: 'You met your goal!' })).toBeInTheDocument();
   });
 
   it('handles click to open/close discussions sidebar', async () => {

--- a/src/courseware/course/course-exit/CourseCelebration.jsx
+++ b/src/courseware/course/course-exit/CourseCelebration.jsx
@@ -79,7 +79,7 @@ const CourseCelebration = () => {
   let message;
   let certHeader;
   let visitEvent = 'celebration_generic';
-  // These cases are taken from the edx-platform `get_cert_data` function found in lms/courseware/views/views.py
+
   switch (certStatus) {
     case 'downloadable':
       certHeader = intl.formatMessage(messages.certificateHeaderDownloadable);
@@ -142,8 +142,6 @@ const CourseCelebration = () => {
       break;
     }
     case 'requesting':
-      // The requesting status needs a different button because it does a POST instead of a GET.
-      // So we don't set buttonLocation and instead define a custom button as a buttonPrefix.
       buttonEvent = 'request_cert';
       buttonPrefix = (
         <Button
@@ -171,7 +169,6 @@ const CourseCelebration = () => {
         buttonText = intl.formatMessage(messages.verifyIdentityButton);
         buttonEvent = 'verify_id';
         buttonLocation = verifyIdentityUrl;
-        // todo: check for idVerificationSupportLink null
         message = (
           <p>
             <FormattedMessage
@@ -189,16 +186,15 @@ const CourseCelebration = () => {
     case 'honor_passing':
       if (verifiedMode) {
         visitEvent = 'celebration_upgrade';
-        footnote = null;
+        if (!verifiedMode.accessExpirationDate) {
+          footnote = <DashboardFootnote variant={visitEvent} />;
+        }
       } else {
         visitEvent = 'celebration_audit_no_upgrade';
       }
       break;
     default:
       if (!canViewCertificate) {
-        //  We reuse the cert event here. Since this default state is so
-        //  Similar to the earned_not_available state, this event name should be fine
-        //  to cover the same cases.
         visitEvent = 'celebration_with_unavailable_cert';
         certHeader = intl.formatMessage(messages.certificateHeaderNotAvailable);
         const endDate = intl.formatDate(end, {
@@ -221,7 +217,11 @@ const CourseCelebration = () => {
       break;
   }
 
-  useEffect(() => logVisit(org, courseId, administrator, visitEvent), [org, courseId, administrator, visitEvent]);
+  useEffect(() => {
+    if (visitEvent !== 'celebration_upgrade') {
+      logVisit(org, courseId, administrator, visitEvent);
+    }
+  }, [org, courseId, administrator, visitEvent]);
 
   return (
     <>

--- a/src/courseware/course/course-exit/CourseCelebration.jsx
+++ b/src/courseware/course/course-exit/CourseCelebration.jsx
@@ -189,7 +189,7 @@ const CourseCelebration = () => {
     case 'honor_passing':
       if (verifiedMode) {
         visitEvent = 'celebration_upgrade';
-        footnote = <DashboardFootnote variant={visitEvent} />;
+        footnote = null;
       } else {
         visitEvent = 'celebration_audit_no_upgrade';
       }

--- a/src/courseware/course/course-exit/CourseCelebration.jsx
+++ b/src/courseware/course/course-exit/CourseCelebration.jsx
@@ -9,7 +9,6 @@ import {
   Alert,
   breakpoints,
   Button,
-  Hyperlink,
   useWindowSize,
 } from '@openedx/paragon';
 import { CheckCircle } from '@openedx/paragon/icons';
@@ -19,18 +18,16 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import CelebrationMobile from './assets/celebration_456x328.gif';
 import CelebrationDesktop from './assets/celebration_750x540.gif';
 import certificate from '../../../generic/assets/edX_certificate.png';
-import certificateLocked from '../../../generic/assets/edX_locked_certificate.png';
-import { FormattedPricing } from '../../../generic/upgrade-button';
 import messages from './messages';
 import { useModel } from '../../../generic/model-store';
 import { requestCert } from '../../../course-home/data/thunks';
 import ProgramCompletion from './ProgramCompletion';
-import UpgradeFootnote from './UpgradeFootnote';
 import SocialIcons from '../../social-share/SocialIcons';
 import { logClick, logVisit } from './utils';
 import { DashboardLink, IdVerificationSupportLink, ProfileLink } from '../../../shared/links';
 import DashboardFootnote from './DashboardFootnote';
 import { CourseRecommendationsSlot } from '../../../plugin-slots/CourseExitPluginSlots';
+import CourseExitUpsellSlot from '../../../plugin-slots/CourseExitUpsellSlot';
 
 const LINKEDIN_BLUE = '#2867B2';
 
@@ -74,10 +71,10 @@ const CourseCelebration = () => {
   let buttonPrefix = null;
   let buttonLocation;
   let buttonText;
-  let buttonVariant = 'outline-primary';
+  const buttonVariant = 'outline-primary';
   let buttonEvent = null;
-  let buttonSuffix = null;
-  let certificateImage = certificate;
+  const buttonSuffix = null;
+  const certificateImage = certificate;
   let footnote;
   let message;
   let certHeader;
@@ -191,56 +188,8 @@ const CourseCelebration = () => {
     case 'audit_passing':
     case 'honor_passing':
       if (verifiedMode) {
-        certHeader = intl.formatMessage(messages.certificateHeaderUpgradable);
-        message = (
-          <p>
-            <FormattedMessage
-              id="courseCelebration.certificateBody.upgradable"
-              defaultMessage="It’s not too late to upgrade. For {price} you will unlock access to all graded
-                assignments in this course. Upon completion, you will receive a verified certificate which is a
-                valuable credential to improve your job prospects and advance your career, or highlight your
-                certificate in school applications."
-              values={{ price: <FormattedPricing inline offer={offer} verifiedMode={verifiedMode} /> }}
-              description="Body text when the learner needs to upgrade to earn a certifcate and they have passed the course"
-            />
-            <br />
-            {getConfig().SUPPORT_URL_VERIFIED_CERTIFICATE && (
-              <Hyperlink
-                className="text-gray-700"
-                style={{ textDecoration: 'underline' }}
-                destination={getConfig().SUPPORT_URL_VERIFIED_CERTIFICATE}
-              >
-                {intl.formatMessage(messages.verifiedCertificateSupportLink)}
-              </Hyperlink>
-            )}
-          </p>
-        );
-        buttonText = intl.formatMessage(messages.upgradeButton);
-        buttonEvent = 'upgrade';
-        buttonLocation = verifiedMode.upgradeUrl;
-        buttonVariant = 'primary';
-        if (offer) {
-          buttonSuffix = (
-            <span className="ml-2 align-middle">
-              <FormattedMessage
-                id="courseCelebration.upgradeDiscountCodePrompt"
-                defaultMessage="Use code {code} at checkout for {percent}% off!"
-                values={{
-                  code: (<b>{offer.code}</b>),
-                  percent: offer.percentage,
-                }}
-                description="Shown if learner can use a discount code when they upgrade the course"
-              />
-            </span>
-          );
-        }
-        certificateImage = certificateLocked;
         visitEvent = 'celebration_upgrade';
-        if (verifiedMode.accessExpirationDate) {
-          footnote = <UpgradeFootnote deadline={verifiedMode.accessExpirationDate} href={verifiedMode.upgradeUrl} />;
-        } else {
-          footnote = <DashboardFootnote variant={visitEvent} />;
-        }
+        footnote = <DashboardFootnote variant={visitEvent} />;
       } else {
         visitEvent = 'celebration_audit_no_upgrade';
       }
@@ -312,6 +261,15 @@ const CourseCelebration = () => {
           )}
         </div>
         <div className="col-12 px-0 px-md-5">
+          {visitEvent === 'celebration_upgrade' && (
+            <CourseExitUpsellSlot
+              courseId={courseId}
+              org={org}
+              administrator={administrator}
+              offer={offer}
+              verifiedMode={verifiedMode}
+            />
+          )}
           {certHeader && (
           <Alert variant="success" icon={CheckCircle}>
             <div className="row w-100 m-0">

--- a/src/courseware/course/course-exit/CourseExit.test.jsx
+++ b/src/courseware/course/course-exit/CourseExit.test.jsx
@@ -21,6 +21,29 @@ import CourseNonPassing from './CourseNonPassing';
 initializeMockApp();
 jest.mock('@edx/frontend-platform/analytics');
 
+jest.mock('../../../plugin-slots/CourseExitUpsellSlot', () => {
+  /* eslint-disable react/prop-types */
+  const CourseExitUpsellSlotMock = ({
+    courseId,
+    org,
+    administrator,
+    offer,
+    verifiedMode,
+  }) => (
+    <div
+      data-testid="course-exit-upsell-slot"
+      data-course-id={courseId}
+      data-org={org}
+      data-administrator={String(administrator)}
+      data-offer={offer ? JSON.stringify(offer) : ''}
+      data-upgrade-url={verifiedMode?.upgradeUrl || ''}
+      data-access-expiration={verifiedMode?.accessExpirationDate || ''}
+    />
+  );
+  /* eslint-enable react/prop-types */
+  return CourseExitUpsellSlotMock;
+});
+
 describe('Course Exit Pages', () => {
   let axiosMock;
   let store;
@@ -179,7 +202,7 @@ describe('Course Exit Pages', () => {
       expect(screen.queryByRole('img', { name: 'Sample certificate' })).not.toBeInTheDocument();
     });
 
-    it('Displays upgrade link when available', async () => {
+    it('Displays upgrade slot when verified mode is available', async () => {
       setMetadata(
         {
           certificate_data: { cert_status: 'audit_passing' },
@@ -194,13 +217,22 @@ describe('Course Exit Pages', () => {
         },
       );
       await fetchAndRender(<CourseCelebration />);
-      // Keep these text checks in sync with "audit only" test below, so it doesn't end up checking for text that is
-      // never actually there, when/if the text changes.
-      expect(screen.getByText('Upgrade to pursue a verified certificate')).toBeInTheDocument();
-      expect(screen.getByText('For €600 you will unlock access', { exact: false })).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'Upgrade now' })).toBeInTheDocument();
-      const node = screen.getByText('Access to this course and its materials', { exact: false });
-      expect(node.textContent).toMatch(/until August 6, 9999\./);
+      // CTA rendering is now the plugin's responsibility via CourseExitUpsellSlot
+      const slot = screen.getByTestId('course-exit-upsell-slot');
+      expect(slot).toBeInTheDocument();
+      expect(slot).toHaveAttribute('data-course-id', courseId);
+      expect(slot).toHaveAttribute('data-org', coursewareMetadata.org);
+      expect(slot).toHaveAttribute('data-administrator', 'false');
+
+      expect(slot).toHaveAttribute(
+        'data-upgrade-url',
+        'http://localhost:18130/basket/add/?sku=8CF08E5',
+      );
+
+      expect(slot).toHaveAttribute(
+        'data-access-expiration',
+        '9999-08-06T12:00:00Z',
+      );
     });
 
     it('Displays nothing if audit only', async () => {
@@ -213,10 +245,7 @@ describe('Course Exit Pages', () => {
         },
       );
       await fetchAndRender(<CourseCelebration />);
-      // Keep these queries in sync with "upgrade link" test above, so we don't end up checking for text that is
-      // never actually there, when/if the text changes.
-      expect(screen.queryByText('Upgrade to pursue a verified certificate')).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Upgrade now' })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('course-exit-upsell-slot')).not.toBeInTheDocument();
     });
 
     it('Displays LinkedIn Add to Profile button', async () => {

--- a/src/plugin-slots/CourseExitUpsellSlot/index.jsx
+++ b/src/plugin-slots/CourseExitUpsellSlot/index.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+
+const CourseExitUpsellSlot = ({
+  courseId,
+  org,
+  administrator,
+  offer,
+  verifiedMode,
+}) => (
+  <PluginSlot
+    id="org.openedx.frontend-app-learning.course-exit-upsell.v1"
+    idAliases={['course_exit_upsell_slot']}
+    pluginProps={{
+      courseId,
+      org,
+      administrator,
+      offer,
+      verifiedMode,
+    }}
+  />
+);
+
+CourseExitUpsellSlot.propTypes = {
+  courseId: PropTypes.string.isRequired,
+  org: PropTypes.string.isRequired,
+  administrator: PropTypes.bool,
+  offer: PropTypes.shape({
+    code: PropTypes.string,
+    percentage: PropTypes.number,
+  }),
+  verifiedMode: PropTypes.shape({
+    upgradeUrl: PropTypes.string,
+    accessExpirationDate: PropTypes.string,
+  }),
+};
+
+CourseExitUpsellSlot.defaultProps = {
+  administrator: false,
+  offer: null,
+  verifiedMode: null,
+};
+
+export default CourseExitUpsellSlot;


### PR DESCRIPTION
### Description

Creates `CourseExitUpsellSlot` and refactors `CourseCelebration.jsx` to replace the hardcoded upgrade CTA with a `PluginSlot`, allowing the widget to be injected via `edx-internal` config.

### Changes

- Created `CourseExitUpsellSlot` — empty slot with `pluginProps` (courseId, org, administrator, offer, verifiedMode)
- Removed hardcoded upgrade CTA logic from `audit_passing`/`honor_passing` case in `CourseCelebration.jsx`
- Inserted `<CourseExitUpsellSlot>` in the render tree (renders only when `visitEvent === 'celebration_upgrade'`)

### Linked PRs

- Plugin widget: [edx/frontend-plugin-advertisements#131](https://github.com/edx/frontend-plugin-advertisements/pull/131)
- Host wiring: [edx/edx-internal#14685](https://github.com/edx/edx-internal/pull/14685)

### Ticket

[LP-943](https://2u-internal.atlassian.net/browse/LP-943)