### PR TITLE
feat: add ProgressTabCourseGradeHeaderSlot plugin slot

### DIFF
--- a/src/course-home/progress-tab/grades/course-grade/CourseGrade.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CourseGrade.jsx
@@ -3,8 +3,8 @@ import { useContextId } from '../../../../data/hooks';
 
 import { useModel } from '../../../../generic/model-store';
 
+import ProgressTabCourseGradeHeaderSlot from '../../../../plugin-slots/ProgressTabCourseGradeHeaderSlot';
 import CourseGradeFooter from './CourseGradeFooter';
-import CourseGradeHeader from './CourseGradeHeader';
 import GradeBar from './GradeBar';
 import CreditInformation from '../../credit-information/CreditInformation';
 
@@ -29,7 +29,9 @@ const CourseGrade = () => {
 
   return (
     <section className="text-dark-700 my-4 rounded raised-card">
-      {(gradesFeatureIsFullyLocked || gradesFeatureIsPartiallyLocked) && <CourseGradeHeader />}
+      {(gradesFeatureIsFullyLocked || gradesFeatureIsPartiallyLocked) && (
+        <ProgressTabCourseGradeHeaderSlot />
+      )}
       <div className={applyLockedOverlay} aria-hidden={gradesFeatureIsFullyLocked}>
         <div className="row w-100 m-0 p-4">
           <div className="col-12 col-sm-6 p-0 pr-sm-5.5">

--- a/src/plugin-slots/ProgressTabCourseGradeHeaderSlot/README.md
+++ b/src/plugin-slots/ProgressTabCourseGradeHeaderSlot/README.md
@@ -1,0 +1,44 @@
+# Progress Tab Course Grade Header Slot
+
+### Slot ID: `org.openedx.frontend.learning.progress_tab_course_grade_header.v1`
+
+### Slot ID Aliases
+* `progress_tab_course_grade_header_slot`
+
+### Props:
+
+## Description
+
+This slot is used to replace or modify the course grade header shown when grades are fully or partially locked.
+
+## Example
+
+The following `env.config.jsx` replaces the default course grade header with custom content.
+
+```js
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const config = {
+  pluginSlots: {
+    'org.openedx.frontend.learning.progress_tab_course_grade_header.v1': {
+      keepDefault: false,
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_course_grade_header',
+            type: DIRECT_PLUGIN,
+            RenderWidget: () => (
+              <div className="p-3">
+                Grade details are currently limited.
+              </div>
+            ),
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default config;
+```

--- a/src/plugin-slots/ProgressTabCourseGradeHeaderSlot/index.jsx
+++ b/src/plugin-slots/ProgressTabCourseGradeHeaderSlot/index.jsx
@@ -1,0 +1,16 @@
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+
+import CourseGradeHeader from '../../course-home/progress-tab/grades/course-grade/CourseGradeHeader';
+
+const ProgressTabCourseGradeHeaderSlot = () => (
+  <PluginSlot
+    id="org.openedx.frontend.learning.progress_tab_course_grade_header.v1"
+    idAliases={['progress_tab_course_grade_header_slot']}
+  >
+    <CourseGradeHeader />
+  </PluginSlot>
+);
+
+ProgressTabCourseGradeHeaderSlot.propTypes = {};
+
+export default ProgressTabCourseGradeHeaderSlot;

--- a/src/plugin-slots/README.md
+++ b/src/plugin-slots/README.md
@@ -23,6 +23,7 @@
 * [`org.openedx.frontend.learning.progress_tab_certificate_status_main_body.v1`](./ProgressTabCertificateStatusMainBodySlot/)
 * [`org.openedx.frontend.learning.progress_tab_certificate_status_side_panel.v1`](./ProgressTabCertificateStatusSidePanelSlot/)
 * [`org.openedx.frontend.learning.progress_tab_course_grade.v1`](./ProgressTabCourseGradeSlot/)
+* [`org.openedx.frontend.learning.progress_tab_course_grade_header.v1`](./ProgressTabCourseGradeHeaderSlot/)
 * [`org.openedx.frontend.learning.progress_tab_grade_breakdown.v1`](./ProgressTabGradeBreakdownSlot/)
 * [`org.openedx.frontend.learning.progress_tab_related_links.v1`](./ProgressTabRelatedLinksSlot/)
 * [`org.openedx.frontend.learning.sequence_container.v1`](./SequenceContainerSlot/)


### PR DESCRIPTION
Introduces a new `ProgressTabCourseGradeHeaderSlot` plugin slot that wraps the `CourseGradeHeader` component on the progress tab. This allows operators and plugins to replace or extend the course grade header shown when grades are fully or partially locked, without modifying core code.

### Changes

- **`ProgressTabCourseGradeHeaderSlot/index.jsx`** *(new)* — Plugin slot with ID `org.openedx.frontend.learning.progress_tab_course_grade_header.v1` that renders `CourseGradeHeader` as its default content.
- **`ProgressTabCourseGradeHeaderSlot/README.md`** *(new)* — Slot documentation with an `env.config.jsx` usage example.
- **`CourseGrade.jsx`** — Replace the direct `<CourseGradeHeader />` render with `<ProgressTabCourseGradeHeaderSlot />`.
- **`plugin-slots/README.md`** — Add the new slot to the plugin slot index.

### Companion PR

- `frontend-plugins`: Extracts the Monarch `DynamicExperienceSlot` banner into a `ProgressTabCourseGradeHeaderPlugin` that targets this slot.

### Screenshot:
<img width="1751" height="901" alt="image-20260724-132029" src="https://github.com/user-attachments/assets/f0c686ea-34c9-46d1-a97b-fe8047a939b2" />

### Testing

- Existing tests continue to pass; the slot renders `CourseGradeHeader` by default with no behavioral change.

### Support ticket:
- [LP-980](https://2u-internal.atlassian.net/browse/LP-980)